### PR TITLE
Animated obstacles turning on the conveyor belt

### DIFF
--- a/Assets/Game Assets/3D Models/Hand/hand_test.fbx.meta
+++ b/Assets/Game Assets/3D Models/Hand/hand_test.fbx.meta
@@ -146,7 +146,7 @@ ModelImporter:
       maskType: 3
       maskSource: {instanceID: 0}
       additiveReferencePoseFrame: 0
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1

--- a/Assets/Game Assets/3D Models/PlayerCharacter/PlayerSushi.fbx.meta
+++ b/Assets/Game Assets/3D Models/PlayerCharacter/PlayerSushi.fbx.meta
@@ -35,7 +35,7 @@ ModelImporter:
     extraExposedTransformPaths: []
     extraUserProperties: []
     clipAnimations: []
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1

--- a/Assets/Game Assets/3D Models/PlayerCharacter/Sushi_animations.fbx.meta
+++ b/Assets/Game Assets/3D Models/PlayerCharacter/Sushi_animations.fbx.meta
@@ -30,7 +30,7 @@ ModelImporter:
     extraExposedTransformPaths: []
     extraUserProperties: []
     clipAnimations: []
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1

--- a/Assets/Game Assets/3D Models/PlayerCharacter/Sushi_run.fbx.meta
+++ b/Assets/Game Assets/3D Models/PlayerCharacter/Sushi_run.fbx.meta
@@ -204,7 +204,7 @@ ModelImporter:
       maskType: 3
       maskSource: {instanceID: 0}
       additiveReferencePoseFrame: 0
-    isReadable: 0
+    isReadable: 1
   meshes:
     lODScreenPercentages: []
     globalScale: 1

--- a/Assets/GameData/HandData/LeftHandData.asset
+++ b/Assets/GameData/HandData/LeftHandData.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: LeftHandData
   m_EditorClassIdentifier: Assembly-CSharp:Hand:HandData
   HandName: Left
-  MovementSpeed: 2
+  MovementSpeed: 4
   GrabAnimationTiming: 0.4
   PlaceAnimationTiming: 0.4
   HiddenPosition: {x: -44, y: 1, z: 49}

--- a/Assets/GameData/HandData/RightHandData.asset
+++ b/Assets/GameData/HandData/RightHandData.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: RightHandData
   m_EditorClassIdentifier: Assembly-CSharp:Hand:HandData
   HandName: Right
-  MovementSpeed: 2
+  MovementSpeed: 4
   GrabAnimationTiming: 0.4
   PlaceAnimationTiming: 0.4
   HiddenPosition: {x: 56, y: 1, z: 49}

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Extras_1.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Extras_1.prefab
@@ -64,7 +64,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Onigiri Variant (1)
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 313114497606363744, guid: 576e443111023a943a87a689519ebefa, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -146,7 +147,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -1.959
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -228,7 +230,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 3.609
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -310,7 +313,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.727
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -496,7 +500,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 9.848
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -570,7 +575,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Onigiri Variant
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 313114497606363744, guid: 576e443111023a943a87a689519ebefa, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -652,7 +658,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.31
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -734,7 +741,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 5.671
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -822,7 +830,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8145193704745134066, guid: 84c7c60b6ee22834fb09895686cb3b8a, type: 3}
       propertyPath: m_Name
-      value: Extraa_1
+      value: Extras_1
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 2558543174677140935, guid: 84c7c60b6ee22834fb09895686cb3b8a, type: 3}
@@ -949,7 +957,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 3.609
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1031,7 +1040,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 4.396
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1113,7 +1123,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 3.124
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1195,7 +1206,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0.913
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1269,7 +1281,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -7.963
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 9132941860047666037, guid: 193944da404006248943dc342afa955b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Extras_2.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Extras_2.prefab
@@ -52,7 +52,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0.072
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -114,7 +115,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0.156
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -176,7 +178,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -342,7 +345,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -1.179
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -404,7 +408,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -478,7 +483,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6725541067965370502, guid: 6d164ba620568704ab0ca5b0717a35cf, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -540,7 +546,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -602,7 +609,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -664,7 +672,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -726,7 +735,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -800,7 +810,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -2.42
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -998,7 +1009,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.121
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1060,7 +1072,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1122,7 +1135,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Extras_3.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Extras_3.prefab
@@ -72,7 +72,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -154,7 +155,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -236,7 +238,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -318,7 +321,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -400,7 +404,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -586,7 +591,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -668,7 +674,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -750,7 +757,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -24.442
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -824,7 +832,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6725541067965370502, guid: 6d164ba620568704ab0ca5b0717a35cf, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -906,7 +915,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1142,7 +1152,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1224,7 +1235,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1306,7 +1318,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1388,7 +1401,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1470,7 +1484,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1552,7 +1567,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1634,7 +1650,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1716,7 +1733,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1798,7 +1816,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -1880,7 +1899,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -5.864
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with Mix 1.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with Mix 1.prefab
@@ -64,7 +64,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 51.338
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8197942668081609049, guid: b06cbe721b7bf534792eb52eaf4af033, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -138,7 +139,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6725541067965370502, guid: 6d164ba620568704ab0ca5b0717a35cf, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -316,7 +318,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8197942668081609049, guid: b06cbe721b7bf534792eb52eaf4af033, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -499,7 +502,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 43.556
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8197942668081609049, guid: b06cbe721b7bf534792eb52eaf4af033, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -573,7 +577,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6128091145542286006, guid: a0a429aca08bcab4f8d8b257c6943a47, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with green sushi 1.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with green sushi 1.prefab
@@ -30,7 +30,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8789779727745303098, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.483
+      value: 1.54
       objectReference: {fileID: 0}
     - target: {fileID: 8789779727745303098, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
       propertyPath: m_LocalRotation.w
@@ -60,7 +60,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -1.959
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -130,7 +131,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 3.609
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -170,7 +172,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8789779727745303098, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.12
+      value: 0.16
       objectReference: {fileID: 0}
     - target: {fileID: 8789779727745303098, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
       propertyPath: m_LocalRotation.w
@@ -200,7 +202,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.727
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -262,7 +265,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6725541067965370502, guid: 6d164ba620568704ab0ca5b0717a35cf, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -436,7 +440,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.166
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -506,7 +511,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.31
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -576,7 +582,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -9.697
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -664,7 +671,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8145193704745134066, guid: 84c7c60b6ee22834fb09895686cb3b8a, type: 3}
       propertyPath: m_Name
-      value: Plate with greed sushi
+      value: Plate with green sushi 1
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 2558543174677140935, guid: 84c7c60b6ee22834fb09895686cb3b8a, type: 3}
@@ -773,7 +780,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 3.609
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -813,7 +821,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8789779727745303098, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.32
+      value: 0.35
       objectReference: {fileID: 0}
     - target: {fileID: 8789779727745303098, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
       propertyPath: m_LocalRotation.w
@@ -843,7 +851,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 4.396
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -913,7 +922,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 3.124
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -983,7 +993,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0.913
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with miso.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with miso.prefab
@@ -10,7 +10,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2988200018777409493, guid: 4320ed34a5a660041b34802f7122b175, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.65
+      value: 2.61
       objectReference: {fileID: 0}
     - target: {fileID: 2988200018777409493, guid: 4320ed34a5a660041b34802f7122b175, type: 3}
       propertyPath: m_LocalPosition.y
@@ -56,7 +56,8 @@ PrefabInstance:
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 2100000, guid: 7d267c3774f2c554d98bef058358de47, type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 224308125850778562, guid: 4320ed34a5a660041b34802f7122b175, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -222,7 +223,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6128091145542286006, guid: a0a429aca08bcab4f8d8b257c6943a47, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -296,7 +298,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 36.245
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8197942668081609049, guid: b06cbe721b7bf534792eb52eaf4af033, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -476,7 +479,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 36.245
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 8197942668081609049, guid: b06cbe721b7bf534792eb52eaf4af033, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with nigiri.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with nigiri.prefab
@@ -52,7 +52,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -114,7 +115,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -176,7 +178,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -342,7 +345,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -404,7 +408,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6725541067965370502, guid: 6d164ba620568704ab0ca5b0717a35cf, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -466,7 +471,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -528,7 +534,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6397342168374958874, guid: 8b7087ed06f873e45853864b81d195cc, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with onigiri.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with onigiri.prefab
@@ -52,7 +52,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Onigiri Variant (2)
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 313114497606363744, guid: 576e443111023a943a87a689519ebefa, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -218,7 +219,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Onigiri Variant (4)
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 313114497606363744, guid: 576e443111023a943a87a689519ebefa, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -389,7 +391,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Onigiri Variant (3)
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 313114497606363744, guid: 576e443111023a943a87a689519ebefa, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -451,7 +454,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Onigiri Variant
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 313114497606363744, guid: 576e443111023a943a87a689519ebefa, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -513,7 +517,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Onigiri Variant (1)
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 313114497606363744, guid: 576e443111023a943a87a689519ebefa, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with red sushi.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with red sushi.prefab
@@ -60,7 +60,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -90
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -130,7 +131,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -90
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -192,7 +194,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6725541067965370502, guid: 6d164ba620568704ab0ca5b0717a35cf, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -366,7 +369,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.166
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -436,7 +440,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -90
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -621,7 +626,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -90
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -691,7 +697,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -90
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with temaki.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with temaki.prefab
@@ -64,7 +64,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 9132941860047666037, guid: 193944da404006248943dc342afa955b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -126,7 +127,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6725541067965370502, guid: 6d164ba620568704ab0ca5b0717a35cf, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -304,7 +306,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 9132941860047666037, guid: 193944da404006248943dc342afa955b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -378,7 +381,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 9132941860047666037, guid: 193944da404006248943dc342afa955b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -452,7 +456,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 9132941860047666037, guid: 193944da404006248943dc342afa955b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -641,7 +646,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 9132941860047666037, guid: 193944da404006248943dc342afa955b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -715,7 +721,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 8.95
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 9132941860047666037, guid: 193944da404006248943dc342afa955b, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with yellow sushi.prefab
+++ b/Assets/Prefabs/Main Game/Obstacles/Plates with food/Plate with yellow sushi.prefab
@@ -60,7 +60,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -1.959
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -130,7 +131,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.727
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -192,7 +194,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6725541067965370502, guid: 6d164ba620568704ab0ca5b0717a35cf, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -366,7 +369,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.166
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -436,7 +440,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -9.697
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -621,7 +626,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 4.396
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -691,7 +697,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0.913
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6025619555322887725, guid: d5d18c568c1a1934c8b6db24277c558c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/1. Set Non + Jumpable + Jumpable right Set Non-Jumpable + Jumpable right + jumpable and.prefab
+++ b/Assets/Resources/Sets/1. Set Non + Jumpable + Jumpable right Set Non-Jumpable + Jumpable right + jumpable and.prefab
@@ -773,11 +773,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 1.110223e-16
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Resources/Sets/10 Set Non-Jumpable Right-Left Middle Non-Passable with Near Jumpable 2.prefab
+++ b/Assets/Resources/Sets/10 Set Non-Jumpable Right-Left Middle Non-Passable with Near Jumpable 2.prefab
@@ -580,7 +580,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Plate with yellow sushi
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5964569571516066681, guid: ee73a6c5e44b58543b5e243218b0ac78, type: 3}
+    - {fileID: 5112325564338067485, guid: ee73a6c5e44b58543b5e243218b0ac78, type: 3}
+    - {fileID: 4254014478013266521, guid: ee73a6c5e44b58543b5e243218b0ac78, type: 3}
+    - {fileID: 6495145419963020526, guid: ee73a6c5e44b58543b5e243218b0ac78, type: 3}
+    - {fileID: 6594447747202918794, guid: ee73a6c5e44b58543b5e243218b0ac78, type: 3}
+    - {fileID: 2733495791202883262, guid: ee73a6c5e44b58543b5e243218b0ac78, type: 3}
+    - {fileID: 8739726026769120587, guid: ee73a6c5e44b58543b5e243218b0ac78, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/12 Set Non-Jumpable Right-Left with Near Jumpable.prefab
+++ b/Assets/Resources/Sets/12 Set Non-Jumpable Right-Left with Near Jumpable.prefab
@@ -118,7 +118,20 @@ PrefabInstance:
       propertyPath: m_Name
       value: Extras_1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5701691517748035669, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 2079272901789063238, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 4193846175484066466, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 6490641824186790873, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 5112325564338067485, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 4254014478013266521, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 6495145419963020526, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 6594447747202918794, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 2733495791202883262, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 8739726026769120587, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 365825896952359578, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 1740076754802229492, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
+    - {fileID: 61137798389242076, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -862,7 +875,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: Plate with green sushi 1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5964569571516066681, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 5701691517748035669, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 2079272901789063238, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 4193846175484066466, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 6490641824186790873, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 5112325564338067485, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 4254014478013266521, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 6495145419963020526, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 6594447747202918794, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 2733495791202883262, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 8739726026769120587, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/15. Set Non-Jumpable Left-Right with both jumpable.prefab
+++ b/Assets/Resources/Sets/15. Set Non-Jumpable Left-Right with both jumpable.prefab
@@ -258,7 +258,12 @@ PrefabInstance:
       propertyPath: m_Name
       value: Plate with onigiri
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7694207770094797404, guid: c47e54e09c3594c43b74458495a30955, type: 3}
+    - {fileID: 333710022542585370, guid: c47e54e09c3594c43b74458495a30955, type: 3}
+    - {fileID: 9052238972174710900, guid: c47e54e09c3594c43b74458495a30955, type: 3}
+    - {fileID: 5484784516731716617, guid: c47e54e09c3594c43b74458495a30955, type: 3}
+    - {fileID: 8631887671304552052, guid: c47e54e09c3594c43b74458495a30955, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -756,7 +761,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Plate with red sushi
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5964569571516066681, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 5112325564338067485, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 4254014478013266521, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 6495145419963020526, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 6594447747202918794, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 2733495791202883262, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 8739726026769120587, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/2. Set non jumpable.prefab
+++ b/Assets/Resources/Sets/2. Set non jumpable.prefab
@@ -410,11 +410,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 1.110223e-16
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Resources/Sets/20 Set Non-Passable Right Jumpable Left.prefab
+++ b/Assets/Resources/Sets/20 Set Non-Passable Right Jumpable Left.prefab
@@ -118,7 +118,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: Plate with green sushi 1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5964569571516066681, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 5701691517748035669, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 2079272901789063238, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 4193846175484066466, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 6490641824186790873, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 5112325564338067485, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 4254014478013266521, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 6495145419963020526, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 6594447747202918794, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 2733495791202883262, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
+    - {fileID: 8739726026769120587, guid: 96d7af8588f7c944c82d2ade1b8aed45, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/21  Set The wall Left grabbed.prefab
+++ b/Assets/Resources/Sets/21  Set The wall Left grabbed.prefab
@@ -130,7 +130,9 @@ PrefabInstance:
       propertyPath: m_Name
       value: Sake Variant 1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6449218881997704633, guid: 9c0a468692be2844fb9d97d43837c9d1, type: 3}
+    - {fileID: 3981301363667672715, guid: 9c0a468692be2844fb9d97d43837c9d1, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/28  Set The wall Right grabbed.prefab
+++ b/Assets/Resources/Sets/28  Set The wall Right grabbed.prefab
@@ -870,11 +870,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 1.110223e-16
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Resources/Sets/3. Set Non-Jumpable Left-Right Middle Non-Passable with Far Jumpable.prefab
+++ b/Assets/Resources/Sets/3. Set Non-Jumpable Left-Right Middle Non-Passable with Far Jumpable.prefab
@@ -604,11 +604,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 1.110223e-16
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Resources/Sets/31 Set forced jump left.prefab
+++ b/Assets/Resources/Sets/31 Set forced jump left.prefab
@@ -184,7 +184,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Extras_1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 282521600392604150, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/32 Set forced jump Right.prefab
+++ b/Assets/Resources/Sets/32 Set forced jump Right.prefab
@@ -184,7 +184,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Extras_1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 282521600392604150, guid: d2f9a28876918ea49a1b6a2cc803ee3c, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/4. Set Non-Jumpable Right-Left with Both Jumpable 1.prefab
+++ b/Assets/Resources/Sets/4. Set Non-Jumpable Right-Left with Both Jumpable 1.prefab
@@ -468,11 +468,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0
+      value: -2.5
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 1.110223e-16
       objectReference: {fileID: 0}
     - target: {fileID: 3302521240586479596, guid: 5bd3cdc52cf8a354696c9c93df846998, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Resources/Sets/6. Set Jumpable Left 6.prefab
+++ b/Assets/Resources/Sets/6. Set Jumpable Left 6.prefab
@@ -133,7 +133,14 @@ PrefabInstance:
       propertyPath: m_Name
       value: Plate with red sushi
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5964569571516066681, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 5112325564338067485, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 4254014478013266521, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 6495145419963020526, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 6594447747202918794, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 2733495791202883262, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
+    - {fileID: 8739726026769120587, guid: 40903f27fb5856845a40ec63e7dfbaf8, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Resources/Sets/9 Set Non-Jumpable Left-Right with near jumpable 6.prefab
+++ b/Assets/Resources/Sets/9 Set Non-Jumpable Left-Right with near jumpable 6.prefab
@@ -118,7 +118,12 @@ PrefabInstance:
       propertyPath: m_Name
       value: Plate with onigiri
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 7694207770094797404, guid: c47e54e09c3594c43b74458495a30955, type: 3}
+    - {fileID: 333710022542585370, guid: c47e54e09c3594c43b74458495a30955, type: 3}
+    - {fileID: 9052238972174710900, guid: c47e54e09c3594c43b74458495a30955, type: 3}
+    - {fileID: 5484784516731716617, guid: c47e54e09c3594c43b74458495a30955, type: 3}
+    - {fileID: 8631887671304552052, guid: c47e54e09c3594c43b74458495a30955, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Scenes/Main Game Scene.unity
+++ b/Assets/Scenes/Main Game Scene.unity
@@ -1722,7 +1722,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3600251912006300813, guid: f084d0afe1904ed43b333608717bf59f, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6496873194134220770, guid: f084d0afe1904ed43b333608717bf59f, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/Main Game Scene.unity
+++ b/Assets/Scenes/Main Game Scene.unity
@@ -1722,7 +1722,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3600251912006300813, guid: f084d0afe1904ed43b333608717bf59f, type: 3}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6496873194134220770, guid: f084d0afe1904ed43b333608717bf59f, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/Main Game Scene.unity
+++ b/Assets/Scenes/Main Game Scene.unity
@@ -207,6 +207,37 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 3362242079466075694, guid: f62ebfde1b918144aa0eb91b97f0d4ac, type: 3}
   m_PrefabInstance: {fileID: 6921550663802349576}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &338123200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 338123201}
+  m_Layer: 0
+  m_Name: TurnEndBPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &338123201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 338123200}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 12.5, y: 1.3372175e-23, z: 243.47203}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1928837765}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &363294582
 GameObject:
   m_ObjectHideFlags: 0
@@ -1044,7 +1075,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f3959a0be561b5549a2501c4a07b881e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _lengthToSpawnPoint: 245
+  _lengthToSpawnPoint: 280
 --- !u!4 &727662354
 Transform:
   m_ObjectHideFlags: 0
@@ -1283,6 +1314,37 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 641ea52b2f3b3d843aa6673cd4d6356a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1315144921
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1315144922}
+  m_Layer: 0
+  m_Name: TurnStartAPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1315144922
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1315144921}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -15.626556, y: 8.559161e-15, z: 256.59833}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1928837765}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1326796487
 GameObject:
   m_ObjectHideFlags: 0
@@ -1344,6 +1406,37 @@ MonoBehaviour:
     rgba: 4282670325
   textStyle: 3
   textAlignment: 1
+--- !u!1 &1352411536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1352411537}
+  m_Layer: 0
+  m_Name: TurnEndAPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1352411537
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1352411536}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.5, y: -1.3372175e-23, z: 243.47194}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1928837765}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1447604127 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8348797882044165656, guid: ddde6e8b28f942747b9caa1208d1ff74, type: 3}
@@ -1365,6 +1458,37 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 5503295699051320710, guid: 60b5309a6474d3d4494a45ac12adedb2, type: 3}
   m_PrefabInstance: {fileID: 8379571648420754887}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1569716423
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1569716424}
+  m_Layer: 0
+  m_Name: TurnStartBPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1569716424
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569716423}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -15.626644, y: 1.897823e-15, z: 271.59833}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1928837765}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1642521205
 GameObject:
   m_ObjectHideFlags: 0
@@ -1562,6 +1686,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _leftHand: {fileID: 1932714195}
   _rightHand: {fileID: 1447604128}
+--- !u!4 &1928837765 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3970547263691793958, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+  m_PrefabInstance: {fileID: 6529361485297883685}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1932714194 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8348797882044165656, guid: ddde6e8b28f942747b9caa1208d1ff74, type: 3}
@@ -2307,6 +2436,30 @@ PrefabInstance:
       propertyPath: _conveyorDespawnDistance
       value: -1
       objectReference: {fileID: 0}
+    - target: {fileID: 3550374355172738631, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      propertyPath: turnEndAPosition
+      value: 
+      objectReference: {fileID: 1352411537}
+    - target: {fileID: 3550374355172738631, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      propertyPath: turnEndBPosition
+      value: 
+      objectReference: {fileID: 338123201}
+    - target: {fileID: 3550374355172738631, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      propertyPath: turnStartAPosition
+      value: 
+      objectReference: {fileID: 1315144922}
+    - target: {fileID: 3550374355172738631, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      propertyPath: turnStartBPosition
+      value: 
+      objectReference: {fileID: 1569716424}
+    - target: {fileID: 3550374355172738631, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      propertyPath: beltTurnEndPosition
+      value: 
+      objectReference: {fileID: 1315144922}
+    - target: {fileID: 3550374355172738631, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      propertyPath: beltTurnStartPosition
+      value: 
+      objectReference: {fileID: 1352411537}
     - target: {fileID: 4437058293172984686, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
       propertyPath: m_TagString
       value: SetMover
@@ -2357,7 +2510,19 @@ PrefabInstance:
       objectReference: {fileID: 660811357}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3970547263691793958, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1352411537}
+    - targetCorrespondingSourceObject: {fileID: 3970547263691793958, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 338123201}
+    - targetCorrespondingSourceObject: {fileID: 3970547263691793958, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1315144922}
+    - targetCorrespondingSourceObject: {fileID: 3970547263691793958, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1569716424}
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 397a94b137e66dd49ba81852c4d76772, type: 3}
 --- !u!1001 &6921550663802349576

--- a/Assets/Scripts/Controllers/SetMover.cs
+++ b/Assets/Scripts/Controllers/SetMover.cs
@@ -11,6 +11,10 @@ namespace Controllers
     [Header("Settings")] 
     [SerializeField] private bool _drawGizmos = true;
     [SerializeField] private float _despawnZPosition = 5f;
+    public Transform turnStartAPosition;
+    public Transform turnStartBPosition;
+    public Transform turnEndAPosition;
+    public Transform turnEndBPosition;
   
     private List<GameObject> _spawnedSets = new List<GameObject>();
     public void AddSet(GameObject set) => _spawnedSets.Add(set);
@@ -21,16 +25,59 @@ namespace Controllers
     {
       if (_drawGizmos)
       {
-        Vector3 pos = new Vector3(0, 0, _despawnZPosition);
-        Vector3 size = new Vector3(10, 10, 0);
-
-        Gizmos.color = Color.red;
-        Gizmos.DrawWireCube(pos, size);
-        
-        Gizmos.DrawLine(new Vector3(-size.x/2, -size.y/2, _despawnZPosition), new Vector3(size.x/2, size.y/2, _despawnZPosition));
-        Gizmos.DrawLine(new Vector3(-size.x/2, size.y/2, _despawnZPosition), new Vector3(size.x/2, -size.y/2, _despawnZPosition));
+        GizmosDrawTurn();
+        GizmosDrawDespawn();
       }      
     }
+
+    private void GizmosDrawDespawn()
+    {
+      // Draw Despawn Zone
+      Vector3 pos = new Vector3(0, 0, _despawnZPosition);
+      Vector3 size = new Vector3(10, 10, 0);
+
+      Gizmos.color = Color.red;
+      Gizmos.DrawWireCube(pos, size);
+        
+      Gizmos.DrawLine(new Vector3(-size.x/2, -size.y/2, _despawnZPosition), new Vector3(size.x/2, size.y/2, _despawnZPosition));
+      Gizmos.DrawLine(new Vector3(-size.x/2, size.y/2, _despawnZPosition), new Vector3(size.x/2, -size.y/2, _despawnZPosition));
+    }
+
+    private void GizmosDrawTurn()
+    {
+      // Draw start and end of turn
+      Vector3 startA = turnStartAPosition.position;
+      Vector3 startB = turnStartBPosition.position;
+      Vector3 endA = turnEndAPosition.position;
+      Vector3 endB = turnEndBPosition.position;
+
+      Gizmos.color = new Color(229f/255f, 154f/255f, 35f/255f, 1);
+      Gizmos.DrawLine(startA, startB);
+      Gizmos.DrawLine(endA, endB);
+      Gizmos.DrawSphere(startA, 0.5f); 
+      Gizmos.DrawSphere(startB, 0.5f); 
+      Gizmos.DrawSphere(endA, 0.5f); 
+      Gizmos.DrawSphere(endB, 0.5f);
+      
+      Vector3 startABd3 = ( startB - startA )/3f;
+      Vector3 endABd3 = (endB - endA)/3f;
+      Vector3 startOffset = startABd3 / 2f + startA;
+      Vector3 endOffset = endABd3 / 2f + endA;
+      Gizmos.color = Color.yellow;
+      for (int i = 0; i < 3; i++)
+      {
+        Vector3 newEndPosition = endOffset + i * endABd3;
+        Vector3 newStartPosition = startOffset + i * startABd3;
+        Gizmos.DrawSphere(newEndPosition, 0.4f);
+        Gizmos.DrawSphere(newStartPosition, 0.4f);
+        
+        // draw line to intersection
+        Vector3 intersectionPoint = new Vector3(newEndPosition.x, newEndPosition.y, newStartPosition.z);
+        Gizmos.DrawLine(newEndPosition, intersectionPoint);
+        Gizmos.DrawLine(newStartPosition, intersectionPoint);
+      }
+    }
+
     public override void InitializeController()
     {
       base.InitializeController();

--- a/Assets/Scripts/Controllers/SetMover.cs
+++ b/Assets/Scripts/Controllers/SetMover.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 using Controllers.Controller;
 using MySingelton;
 using Sets;
@@ -25,9 +27,62 @@ namespace Controllers
     {
       if (_drawGizmos)
       {
-        GizmosDrawTurn();
+        //GizmosDrawSharpTurn();
+        DrawTurnBounds();
+        GizmosDrawArcTurn();
         GizmosDrawDespawn();
       }      
+    }
+
+    private void DrawTurnBounds()
+    {
+      Vector3 startA = turnStartAPosition.position;
+      Vector3 startB = turnStartBPosition.position;
+      Vector3 endA = turnEndAPosition.position;
+      Vector3 endB = turnEndBPosition.position;
+
+      Gizmos.color = new Color(229f/255f, 154f/255f, 35f/255f, 1);
+      Gizmos.DrawLine(startA, startB);
+      Gizmos.DrawLine(endA, endB);
+      Gizmos.DrawSphere(startA, 0.5f); 
+      Gizmos.DrawSphere(startB, 0.5f); 
+      Gizmos.DrawSphere(endA, 0.5f); 
+      Gizmos.DrawSphere(endB, 0.5f);
+    }
+
+    private void GizmosDrawArcTurn()
+    {
+      Vector3 startA = turnStartAPosition.position;
+      Vector3 startB = turnStartBPosition.position;
+      Vector3 endA = turnEndAPosition.position;
+      Vector3 endB = turnEndBPosition.position;
+
+      // precalculate offsets
+      Vector3 displacement = endB - endA;
+      Vector3 dispD3 = displacement / 3f;
+
+      float radius(float x0, float x1) => x0 - x1;
+      const int segments = 20;
+      for (int i = 0; i < 3; i++)
+      {
+        float xi = endA.x + dispD3.x / 2f + dispD3.x * i;
+        float rad = radius(startA.x, xi);
+        Vector3[] points = new Vector3[segments + 1];
+        for (int n = 0; n <= segments; n++)
+        {
+          float angle = ((float)n / segments) * Mathf.PI * 0.5f;
+          float newX = rad * (float)Math.Cos(angle);
+          float newY = rad * (float)Math.Sin(angle);
+
+          points[n] = new Vector3(startA.x - newX, endA.y, endA.z - newY);
+        }
+
+        Gizmos.color = Color.yellow;
+        for (int n = 1; n < points.Length; n++)
+        {
+          Gizmos.DrawLine(points[n - 1], points[n]);
+        }
+      }
     }
 
     private void GizmosDrawDespawn()
@@ -43,21 +98,13 @@ namespace Controllers
       Gizmos.DrawLine(new Vector3(-size.x/2, size.y/2, _despawnZPosition), new Vector3(size.x/2, -size.y/2, _despawnZPosition));
     }
 
-    private void GizmosDrawTurn()
+    private void GizmosDrawSharpTurn()
     {
       // Draw start and end of turn
       Vector3 startA = turnStartAPosition.position;
       Vector3 startB = turnStartBPosition.position;
       Vector3 endA = turnEndAPosition.position;
       Vector3 endB = turnEndBPosition.position;
-
-      Gizmos.color = new Color(229f/255f, 154f/255f, 35f/255f, 1);
-      Gizmos.DrawLine(startA, startB);
-      Gizmos.DrawLine(endA, endB);
-      Gizmos.DrawSphere(startA, 0.5f); 
-      Gizmos.DrawSphere(startB, 0.5f); 
-      Gizmos.DrawSphere(endA, 0.5f); 
-      Gizmos.DrawSphere(endB, 0.5f);
       
       Vector3 startABd3 = ( startB - startA )/3f;
       Vector3 endABd3 = (endB - endA)/3f;

--- a/Assets/Scripts/Controllers/SetSpawner/SetSpawner.cs
+++ b/Assets/Scripts/Controllers/SetSpawner/SetSpawner.cs
@@ -133,12 +133,6 @@ namespace Controllers
             Gizmos.DrawSphere(startPosition, 0.5f);
             Gizmos.DrawLine(startPosition, endPosition);
             Gizmos.DrawSphere(endPosition, 0.5f);
-
-            if (Application.isPlaying)
-            {
-                (Vector3 start, Vector3 end) = _turnAnimator.GetLinePoints(-40, 40);
-                Gizmos.DrawLine(start, end);
-            }
         }
     }
 }

--- a/Assets/Scripts/Controllers/SetSpawner/SetSpawner.cs
+++ b/Assets/Scripts/Controllers/SetSpawner/SetSpawner.cs
@@ -23,6 +23,7 @@ namespace Controllers
         private SetMover _setMover;
         private HandDelegator _handDelegator;
         private ConveyorBelt _conveyorBelt;
+        private TurnAnimator _turnAnimator;
         
         [Header("Settings")]
         [SerializeField] private float _lengthToSpawnPoint = 5f;
@@ -38,6 +39,8 @@ namespace Controllers
             _setMover = GameObject.FindGameObjectWithTag("SetMover").GetComponent<SetMover>();
             _setParent = new GameObject("Set Parent");
             _conveyorBelt = GameObject.FindGameObjectWithTag("ConveyorBelt").GetComponent<ConveyorBelt>();
+
+            _turnAnimator = new TurnAnimator(_setMover);
         }
 
         private void Update()
@@ -46,6 +49,7 @@ namespace Controllers
                 return;
             
             LoopSpawning();
+            _turnAnimator.Animate();
         }
 
         // Test method
@@ -98,6 +102,7 @@ namespace Controllers
             set.transform.parent = _setParent.transform;
             LatestSpawnedSet = set;
             _setMover.AddSet(LatestSpawnedSet.gameObject);
+            _turnAnimator.AddSet(LatestSpawnedSet);
         }
 
         
@@ -128,6 +133,12 @@ namespace Controllers
             Gizmos.DrawSphere(startPosition, 0.5f);
             Gizmos.DrawLine(startPosition, endPosition);
             Gizmos.DrawSphere(endPosition, 0.5f);
+
+            if (Application.isPlaying)
+            {
+                (Vector3 start, Vector3 end) = _turnAnimator.GetLinePoints(-40, 40);
+                Gizmos.DrawLine(start, end);
+            }
         }
     }
 }

--- a/Assets/Scripts/Controllers/SetSpawner/SetSpawner.cs
+++ b/Assets/Scripts/Controllers/SetSpawner/SetSpawner.cs
@@ -23,7 +23,6 @@ namespace Controllers
         private SetMover _setMover;
         private HandDelegator _handDelegator;
         private ConveyorBelt _conveyorBelt;
-        private TurnAnimator _turnAnimator;
         
         [Header("Settings")]
         [SerializeField] private float _lengthToSpawnPoint = 5f;
@@ -40,7 +39,6 @@ namespace Controllers
             _setParent = new GameObject("Set Parent");
             _conveyorBelt = GameObject.FindGameObjectWithTag("ConveyorBelt").GetComponent<ConveyorBelt>();
 
-            _turnAnimator = new TurnAnimator(_setMover);
         }
 
         private void Update()
@@ -49,7 +47,6 @@ namespace Controllers
                 return;
             
             LoopSpawning();
-            _turnAnimator.Animate();
         }
 
         // Test method
@@ -101,11 +98,8 @@ namespace Controllers
         
             set.transform.parent = _setParent.transform;
             LatestSpawnedSet = set;
-            _setMover.AddSet(LatestSpawnedSet.gameObject);
-            _turnAnimator.AddSet(LatestSpawnedSet);
+            _setMover.AddSet(LatestSpawnedSet);
         }
-
-        
         
         
         private ConveyorBelt TryFindConveyorBelt()

--- a/Assets/Scripts/Controllers/SetSpawner/TurnAnimator.cs
+++ b/Assets/Scripts/Controllers/SetSpawner/TurnAnimator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Gaskellgames;
 using Sets;
 using UnityEngine;
@@ -50,10 +51,7 @@ namespace Controllers
         if (set.transform.position.z + set.Length <= _setMover.turnEndAPosition.position.z)
         {
           _sets.Remove(set);
-          foreach (Obstacle obstacle in set.MyChildren)
-          {
-            obstacle.transform.localPosition = obstacle.OriginalPosition;
-          }
+          Array.ForEach(set.MyChildren, child => child.ResetTransform());
           continue;
         }
 
@@ -65,7 +63,7 @@ namespace Controllers
 
           if (dist <= 0f)
           {
-            obstacle.transform.localPosition = obstacle.OriginalPosition;
+            obstacle.ResetTransform();
             continue;
           }
           

--- a/Assets/Scripts/Controllers/SetSpawner/TurnAnimator.cs
+++ b/Assets/Scripts/Controllers/SetSpawner/TurnAnimator.cs
@@ -47,36 +47,31 @@ namespace Controllers
           float dist = obstaclePos.z - _endPosition.z;
           float angle = dist / circD4 * halfPI;
           
-          
-
-          if (angle > halfPI)
+          if (angle <= 0) // reset
           {
-            // draw linearly
-            float linearX = _startPosition.z + obstaclePos.x - _endPosition.x;
-            float linearZ = _startPosition.x - (dist - circD4);
-
-            Quaternion rotation = Quaternion.Euler(0, -90, 0);
-            Quaternion result = obstacleOrgRotation * rotation;
-            obstacle.transform.rotation = result;
-            
-            obstacle.transform.position = new Vector3(linearZ, obstaclePos.y, linearX);
-            continue;
-          }
-
-          if (angle <= 0)
-          {
-            // reset 
             obstacle.ResetTransform();
             continue;
           }
 
-          // draw on arc
-          Quaternion turnRotation = Quaternion.Euler(0, (angle / halfPI) * -90, 0);
-          Quaternion turnResult = obstacleOrgRotation * turnRotation;
-          obstacle.transform.rotation = turnResult;
-          float arcX = _startPosition.x + rad * Mathf.Cos(angle);
-          float arcZ = _endPosition.z + rad * Mathf.Sin(angle);
-          obstacle.transform.position = new Vector3(arcX, obstaclePos.y, arcZ); 
+          float newX, newZ;
+          Quaternion rotation, result;
+          if (angle > halfPI) // draw linearly
+          {
+            newX = _startPosition.x - (dist - circD4);
+            newZ = _startPosition.z + obstaclePos.x - _endPosition.x;
+
+            rotation = Quaternion.Euler(0, -90, 0);
+            result = obstacleOrgRotation * rotation;
+          }
+          else // draw on arc path
+          {
+            rotation = Quaternion.Euler(0, (angle / halfPI) * -90, 0);
+            result = obstacleOrgRotation * rotation;
+            newX = _startPosition.x + rad * Mathf.Cos(angle);
+            newZ = _endPosition.z + rad * Mathf.Sin(angle);
+          }
+          obstacle.transform.position = new Vector3(newX, obstaclePos.y, newZ); 
+          obstacle.transform.rotation = result;
         }
 
       }

--- a/Assets/Scripts/Controllers/SetSpawner/TurnAnimator.cs
+++ b/Assets/Scripts/Controllers/SetSpawner/TurnAnimator.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using Gaskellgames;
+using Sets;
+using UnityEngine;
+
+namespace Controllers
+{
+  public class TurnAnimator
+  {
+    private readonly SetMover _setMover;
+    private readonly List<Set> _sets = new();
+
+    private struct KXMLine
+    {
+      public float k;
+      public float m;
+    }
+    private KXMLine line;
+
+    public (Vector3, Vector3) GetLinePoints(float x0, float x1)
+    {
+      var vX0 = CalculateIntersectionOnLine(x0);
+      var vX1 = CalculateIntersectionOnLine(x1);
+      Vector3 newVX0 = new Vector3(vX0.x, 0, vX0.y);
+      Vector3 newVX1 = new Vector3(vX1.x, 0, vX1.y);
+      return (
+        newVX0, newVX1
+      );
+    }
+        
+    public TurnAnimator(SetMover setMover)
+    {
+      _setMover = setMover;
+            
+      // initialize intersection line
+      Vector2 start = GetLaneIntersection(0);
+      Vector2 end = GetLaneIntersection(2);
+      line = new KXMLine();
+      line.k = (end.y - start.y) / (end.x - start.x);
+      line.m = start.y - line.k * start.x;
+    }
+
+    public void Animate()
+    {
+      for(int i=_sets.Count - 1; i >= 0; i--)
+      {
+        Set set = _sets[i];
+        
+        // reset obstacles and return set
+        if (set.transform.position.z + set.Length <= _setMover.turnEndAPosition.position.z)
+        {
+          _sets.Remove(set);
+          foreach (Obstacle obstacle in set.MyChildren)
+          {
+            obstacle.transform.localPosition = obstacle.OriginalPosition;
+          }
+          continue;
+        }
+
+        foreach (Obstacle obstacle in set.MyChildren)
+        {
+          Vector3 obstaclePosition = set.transform.position + obstacle.OriginalPosition;
+          Vector2 intersectionPoint = CalculateIntersectionOnLine(obstaclePosition.x);
+          float dist = obstaclePosition.z - intersectionPoint.y;
+
+          if (dist <= 0f)
+          {
+            obstacle.transform.localPosition = obstacle.OriginalPosition;
+            continue;
+          }
+          
+          // translate position 
+          Vector3 newPosition = new Vector3(intersectionPoint.x - dist, obstaclePosition.y, intersectionPoint.y);
+          obstacle.transform.position = newPosition;
+        }        
+               
+      }
+    }
+    public void AddSet(Set set) => _sets.Add(set);
+
+    private Vector2 CalculateIntersectionOnLine(float x)
+    {
+      return new Vector3(x, line.k * x + line.m);
+    }
+
+    private Vector2 GetLaneIntersection(int lane)
+    {
+      lane = Mathf.Clamp(lane, 0, 3);
+            
+      // start positions
+      Vector3 startAPosition = _setMover.turnStartAPosition.position;
+      Vector3 startBPosition = _setMover.turnStartBPosition.position;
+      Vector3 startABd3 = (startBPosition - startAPosition) / 3f;
+      Vector3 startPos = startABd3 / 2f + startABd3 * lane;
+            
+      // end positions
+      Vector3 endAPosition = _setMover.turnEndAPosition.position;
+      Vector3 endBPosition = _setMover.turnEndBPosition.position;
+      Vector3 endABd3 = (endBPosition - endAPosition) / 3f;
+      Vector3 endPos = endABd3 / 2f + endABd3 * lane;
+            
+      // intersection
+      return new Vector2(endAPosition.x + endPos.x, startAPosition.z + startPos.z);
+    }
+       
+  }
+}

--- a/Assets/Scripts/Controllers/SetSpawner/TurnAnimator.cs.meta
+++ b/Assets/Scripts/Controllers/SetSpawner/TurnAnimator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8c0f6d505eef489da6fb3dc74b95928e
+timeCreated: 1733240033

--- a/Assets/Scripts/Sets/Obstacle.cs
+++ b/Assets/Scripts/Sets/Obstacle.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using UnityEngine;
 
 namespace Sets
@@ -25,6 +27,21 @@ namespace Sets
             _childColliders = GetComponentsInChildren<Collider>();  
             myCollider = GetComponent<Collider>();
         }
+        
+#if UNITY_EDITOR
+        bool hasDebugged = false;
+        private void OnDrawGizmos()
+        {
+            Obstacle[] children = GetComponentsInChildren<Obstacle>();
+            if(children != null && children.Length > 1 && hasDebugged != true)
+            {
+                hasDebugged = true;
+                Debug.LogError("Obstacles cannot contain children obstacle components. Please remove the component and try again.\n" +
+                               "Objects causing problems:\n" + 
+                               string.Join(",\n", children.Select(x => x.gameObject.name).ToArray()));
+            }
+        }
+#endif
 
         public bool IsVisible
         {
@@ -49,6 +66,13 @@ namespace Sets
         public Vector3 OriginalPosition;
         public Quaternion OriginalRotation;
         public Vector3 OriginalScale;
+
+        public void ResetTransform()
+        {
+            this.transform.localPosition = OriginalPosition;
+            this.transform.localRotation = OriginalRotation;
+            this.transform.localScale = OriginalScale;
+        }
         public bool IsInitialized;
     }
 }

--- a/Assets/Scripts/Sets/Obstacle.cs
+++ b/Assets/Scripts/Sets/Obstacle.cs
@@ -73,6 +73,8 @@ namespace Sets
             this.transform.localRotation = OriginalRotation;
             this.transform.localScale = OriginalScale;
         }
+
+        public Vector3 GetRealPosition() => OwningSet.transform.position + OriginalPosition;
         public bool IsInitialized;
     }
 }

--- a/Assets/Scripts/Sets/Set.cs
+++ b/Assets/Scripts/Sets/Set.cs
@@ -81,6 +81,7 @@ namespace Sets
 
 
         private Obstacle[] _children;
+        public Obstacle[] MyChildren => _children;
         private bool _isInitialized = false;
         public void Initialize()
         {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.singularitygroup.hotreload": "git+https://gitlab.hotreload.net/root/hot-reload-releases.git#1.12.14",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ai.navigation": "2.0.4",
     "com.unity.collab-proxy": "2.5.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,15 @@
 {
   "dependencies": {
+    "com.singularitygroup.hotreload": {
+      "version": "git+https://gitlab.hotreload.net/root/hot-reload-releases.git#1.12.14",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0"
+      },
+      "hash": "9f9c6863d0fce36ec96da4c98d226d63780daab5"
+    },
     "com.unity.2d.sprite": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
# Obstacles will now turn on the conveyor belt
In summary, obstacles no longer visible appear out of thin air in front of the player. The sets still spawn at the same positions as before, but now the obstacles positions in relation to the end of the curved conveyor belt is now translated to a point on the belt and mapped to the correct position and rotation on the curve.

I'm happy about this change as I have been thinking about it for a while, and IT LOOKS SO GOOD!